### PR TITLE
merging `ec2_erik` into `erik`

### DIFF
--- a/python/apple_mava/ff_mappo.py
+++ b/python/apple_mava/ff_mappo.py
@@ -31,9 +31,9 @@ from mava.types import (
 # our custom implementations
 from apple_mava.ff_networks import Actor, Critic 
 
-def apply_baseline_config(config: DictConfig, use_baseline: bool) -> DictConfig:
+def apply_baseline_config(config: DictConfig) -> DictConfig:
     """Applies minimal values to model parameters to allow for easy review of printed outputs."""
-    if use_baseline:
+    if config["system"]["use_baseline"]:
         baseline_config = {
                           "system": {
                               "update_batch_size": 1,

--- a/python/apple_mava/ff_mappo.py
+++ b/python/apple_mava/ff_mappo.py
@@ -7,7 +7,7 @@ import flax.jax_utils  # For utility functions such as `replicate`
 from flax.training import checkpoints
 import jumanji
 from jax import tree
-from typing import Tuple, Any  # For type annotations
+from typing import Tuple, Any, Dict  # For type annotations
 from omegaconf import DictConfig, OmegaConf  # For handling configuration
 from flax.core.frozen_dict import FrozenDict
 from optax._src.base import OptState
@@ -19,7 +19,7 @@ from mava.utils.jax_utils import (
     unreplicate_batch_dim,
     unreplicate_n_dims,
 )
-from mava.systems.ppo.types import LearnerState, OptStates, Params, PPOTransition
+from mava.systems.ppo.types import LearnerState, OptStates, Params
 from mava.utils.training import make_learning_rate
 from mava.types import (
     ExperimentOutput,
@@ -28,8 +28,25 @@ from mava.types import (
     CriticApply,
 )
 
+# the following is being added because of modifications being made to the underlying packages downloaded from mava repo.  This is not necessary for ec2 instance but is necessary for any new download from mava. (i.e. beginning of notebooks)
+import chex
+from typing_extensions import NamedTuple
+from mava.types import Action, Done, HiddenState, Observation, State, Value
+class PPOTransition(NamedTuple):
+    """Transition tuple for PPO."""
+
+    done: Done
+    action: Action
+    value: Value
+    reward: chex.Array
+    log_prob: chex.Array
+    obs: Observation
+    info: Dict
+    
 # our custom implementations
 from apple_mava.ff_networks import Actor, Critic 
+
+
 
 def apply_baseline_config(config: DictConfig) -> DictConfig:
     """Applies minimal values to model parameters to allow for easy review of printed outputs."""

--- a/python/apple_mava/render_logging.py
+++ b/python/apple_mava/render_logging.py
@@ -20,10 +20,13 @@ from jumanji_env.environments.complex_orchard.constants import TICK_SPEED
 
 def render_one_episode_simple(orchard_version_name, config, params, max_steps, verbose=True) -> None:
     """Simulates and visualises one episode from rolling out a trained MAPPO model that will be passed to the function using actors_params."""
+    
     # Create envs
     env_config = {**config.env.kwargs, **config.env.scenario.env_kwargs}
     env, eval_env = make_env(orchard_version_name, config)
 
+    env._env.time_limit = max_steps  # Override time limit directly
+    
     # Create actor networks (We only care about the policy during rendering)
     actor_network = Actor(env.action_dim)
     apply_fn = actor_network.apply
@@ -106,7 +109,7 @@ def render_one_episode_simple(orchard_version_name, config, params, max_steps, v
 def render_one_episode_complex(orchard_version_name, config, params, max_steps, verbose=True) -> None:
     """Simulates and visualises one episode from rolling out a trained MAPPO model that will be passed to the function using actors_params."""
     # Create envs
-    env_config = {**config.env.kwargs, **config.env.scenario.env_kwargs}
+    # env_config = {**config.env.kwargs, **config.env.scenario.env_kwargs}
     env, eval_env = make_complex_env(orchard_version_name, config)
 
     # Create actor networks (We only care about the policy during rendering)

--- a/python/apple_mava/render_logging.py
+++ b/python/apple_mava/render_logging.py
@@ -22,10 +22,7 @@ def render_one_episode_simple(orchard_version_name, config, params, max_steps, v
     """Simulates and visualises one episode from rolling out a trained MAPPO model that will be passed to the function using actors_params."""
     
     # Create envs
-    env_config = {**config.env.kwargs, **config.env.scenario.env_kwargs}
     env, eval_env = make_env(orchard_version_name, config)
-
-    env._env.time_limit = max_steps  # Override time limit directly
     
     # Create actor networks (We only care about the policy during rendering)
     actor_network = Actor(env.action_dim)

--- a/python/jumanji_env/environments/complex_orchard/custom_mava.py
+++ b/python/jumanji_env/environments/complex_orchard/custom_mava.py
@@ -22,7 +22,7 @@ from jumanji_env.environments.complex_orchard.env import ComplexOrchard
 # This function replaces functionality of Mava's `mava.utils.make_env` functionality. 
 # right now this just contains the RecordEpisodeMetrics wrapper and does not contain an equivalent
 # to the LbfWrapper
-def make_env(env_name: str, config: DictConfig, add_global_state: bool = False) -> Tuple[MarlEnv, MarlEnv]:
+def make_env(env_name: str, config: DictConfig, add_global_state: bool = False, use_individual_rewards: bool = False) -> Tuple[MarlEnv, MarlEnv]:
     """
     Create Jumanji environments for training and evaluation.
 

--- a/python/train/config.py
+++ b/python/train/config.py
@@ -1,6 +1,7 @@
 # configuration for environment and models
 config = {
     "system": {
+        "use_baseline": False,
         "actor_lr": 2.5e-4,
         "critic_lr": 2.5e-4,
         "update_batch_size": 2,
@@ -21,19 +22,21 @@ config = {
     "arch": {
         "num_envs": 512,
         "num_eval_episodes": 32,
-        "num_evaluation": 200,
+        "num_evaluation": 300,
         "evaluation_greedy": False,
         "num_absolute_metric_eval_episodes": 32,
+        "use_individual_rewards": False
     },
     "env": {
         "eval_metric": "episode_return",
         "implicit_agent_id": False,
         "log_win_rate": False,
-        "kwargs": {"time_limit": 500},
+        "render_time_limit": 1500,
+        "train_time_limit": 500,
         "scenario": {
             "task_config": {
-                "width": 1200,
-                "height": 1200,
+                "width": 500,
+                "height": 500,
                 "num_picker_bots": 2,
                 "num_pusher_bots": 0,
                 "num_baskets": 1,


### PR DESCRIPTION
The main changes for this update is to allow for different episode lengths between training and rendering.
the MAPPO model also now directly creates the PPOTransition type, instead of pulling from Mava due to repo changes. 